### PR TITLE
Regenerate promotion-orchestrator/models_gen.go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=v1.3.4
+VERSION=v1.4.0
 
 ifndef GOBIN
 ifndef GOPATH


### PR DESCRIPTION
This regen adds a new property `CommitterAvatarUrl` that I've added in https://github.com/codefresh-io/argo-platform/pull/5617 to the `CommitInfoArgs` type which is needed by the gitops-operator: https://github.com/codefresh-io/codefresh-gitops-operator/pull/87

The rest of the changes are just syncing this with other changes made to the argo-platform graphql types.