### PR TITLE
add .idea directory to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 go.work
 
 cover
+
+# Jetbrains Goland IDE folder
+.idea


### PR DESCRIPTION
I opened this repo in Goland (the Jetbrains Go IDE) and it is showing the .idea directory with the jetbrains config files.

Adding this to just ignore those so they don't show up in git.