### PR TITLE
Update models for supporting promotion workflows resumed by isAncestor check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=v1.4.9
+VERSION=v1.4.10
 
 ifndef GOBIN
 ifndef GOPATH

--- a/pkg/model/app-proxy/models_gen.go
+++ b/pkg/model/app-proxy/models_gen.go
@@ -490,6 +490,10 @@ type AccountFeatures struct {
 	GitopsEnvironmentsGroupedMode *bool `json:"gitopsEnvironmentsGroupedMode,omitempty"`
 	// Adds ability to promote files from relative path
 	RelativeFilesPromotions *bool `json:"relativeFilesPromotions,omitempty"`
+	// Adds ability to connect Gitlab as git provider in runtime installation wizard
+	GitlabSupportInRuntimeWizard *bool `json:"gitlabSupportInRuntimeWizard,omitempty"`
+	// Adds ability to connect Bitbucket as git provider in runtime installation wizard
+	BitbucketSupportInRuntimeWizard *bool `json:"bitbucketSupportInRuntimeWizard,omitempty"`
 }
 
 // Account Gitops Usage
@@ -1844,7 +1848,7 @@ type ApplicationLogsOptionsInput struct {
 	SinceSeconds *int `json:"sinceSeconds,omitempty"`
 	// An RFC3339 timestamp from which to show logs. (example: 2023-10-01T00:00:00Z)
 	SinceTime *string `json:"sinceTime,omitempty"`
-	// An RFC3339 timestamp to which to show logs. (example: 2023-10-02T00:00:00Z)
+	// An RFC3339 timestamp to which to show logs (example: 2023-10-02T00:00:00Z)
 	UntilTime *string `json:"untilTime,omitempty"`
 }
 
@@ -5894,6 +5898,16 @@ type Invoice struct {
 	PaymentMethod *PaymentMethod `json:"paymentMethod,omitempty"`
 	// Status
 	Status InvoiceStatus `json:"status"`
+}
+
+// ISC Repository data
+type IscRepository struct {
+	// Repository URL
+	URL string `json:"url"`
+	// Repository branch. Not implemented yet, added to avoid breaking changes in schema in the future
+	Branch *string `json:"branch,omitempty"`
+	// Repository path. Not implemented yet, added to avoid breaking changes in schema in the future
+	Path *string `json:"path,omitempty"`
 }
 
 // Issue value
@@ -10959,6 +10973,7 @@ const (
 	AbacActionNamesRolloutAbort           AbacActionNames = "ROLLOUT_ABORT"
 	AbacActionNamesRolloutPause           AbacActionNames = "ROLLOUT_PAUSE"
 	AbacActionNamesRolloutPromoteFull     AbacActionNames = "ROLLOUT_PROMOTE_FULL"
+	AbacActionNamesRolloutRestart         AbacActionNames = "ROLLOUT_RESTART"
 	AbacActionNamesRolloutResume          AbacActionNames = "ROLLOUT_RESUME"
 	AbacActionNamesRolloutRetry           AbacActionNames = "ROLLOUT_RETRY"
 	AbacActionNamesRolloutSkipCurrentStep AbacActionNames = "ROLLOUT_SKIP_CURRENT_STEP"
@@ -10986,6 +11001,7 @@ var AllAbacActionNames = []AbacActionNames{
 	AbacActionNamesRolloutAbort,
 	AbacActionNamesRolloutPause,
 	AbacActionNamesRolloutPromoteFull,
+	AbacActionNamesRolloutRestart,
 	AbacActionNamesRolloutResume,
 	AbacActionNamesRolloutRetry,
 	AbacActionNamesRolloutSkipCurrentStep,
@@ -11000,7 +11016,7 @@ var AllAbacActionNames = []AbacActionNames{
 
 func (e AbacActionNames) IsValid() bool {
 	switch e {
-	case AbacActionNamesAccessArtifacts, AbacActionNamesAccessLogs, AbacActionNamesAppRollback, AbacActionNamesCreate, AbacActionNamesDeleteResource, AbacActionNamesExecToPod, AbacActionNamesPromoteTo, AbacActionNamesRefresh, AbacActionNamesRestart, AbacActionNamesResubmit, AbacActionNamesRetryRelease, AbacActionNamesRolloutAbort, AbacActionNamesRolloutPause, AbacActionNamesRolloutPromoteFull, AbacActionNamesRolloutResume, AbacActionNamesRolloutRetry, AbacActionNamesRolloutSkipCurrentStep, AbacActionNamesStop, AbacActionNamesSync, AbacActionNamesTerminate, AbacActionNamesTerminateSync, AbacActionNamesTriggerPromotion, AbacActionNamesView, AbacActionNamesViewPodLogs:
+	case AbacActionNamesAccessArtifacts, AbacActionNamesAccessLogs, AbacActionNamesAppRollback, AbacActionNamesCreate, AbacActionNamesDeleteResource, AbacActionNamesExecToPod, AbacActionNamesPromoteTo, AbacActionNamesRefresh, AbacActionNamesRestart, AbacActionNamesResubmit, AbacActionNamesRetryRelease, AbacActionNamesRolloutAbort, AbacActionNamesRolloutPause, AbacActionNamesRolloutPromoteFull, AbacActionNamesRolloutRestart, AbacActionNamesRolloutResume, AbacActionNamesRolloutRetry, AbacActionNamesRolloutSkipCurrentStep, AbacActionNamesStop, AbacActionNamesSync, AbacActionNamesTerminate, AbacActionNamesTerminateSync, AbacActionNamesTriggerPromotion, AbacActionNamesView, AbacActionNamesViewPodLogs:
 		return true
 	}
 	return false

--- a/pkg/model/platform/models_gen.go
+++ b/pkg/model/platform/models_gen.go
@@ -393,6 +393,8 @@ type AccountFeatures struct {
 	ClassicEnvironments *bool `json:"classicEnvironments,omitempty"`
 	// Hide git-sources and related applications without git permissions and when permissions are not provided
 	CsdpFilterAppsByGitPermissions *bool `json:"csdpFilterAppsByGitPermissions,omitempty"`
+	// Gitops Application Tree optimization. It will use improved MongoDB agregation pipeline when enabled. Gitops apps and app sets will be extracted from DB without heavy manifest fields (when need to read >2k items)
+	CsdpAppAndAppSetWithoutManifestFields *bool `json:"csdpAppAndAppSetWithoutManifestFields,omitempty"`
 	// Hide Compositions item in navigation menu
 	HideCompositionsMenuItem *bool `json:"hideCompositionsMenuItem,omitempty"`
 	// Hide Helm Boards item in navigation menu
@@ -487,7 +489,7 @@ type AccountFeatures struct {
 	UnmappedAppsProductView *bool `json:"unmappedAppsProductView,omitempty"`
 	// Hide native workflow link
 	HideNativeWorkflowLink *bool `json:"hideNativeWorkflowLink,omitempty"`
-	// Locking user on billing page when not paying
+	// Enable enforcement according to GitOps Plan. Includes monitoring resource limits and disabling actions, showing banners when plan limits reached.
 	GitopsPlanEnforcement *bool `json:"gitopsPlanEnforcement,omitempty"`
 	// Hides delete, resubmit, terminate and suspend workflow actions
 	HideWorkflowActions *bool `json:"hideWorkflowActions,omitempty"`
@@ -495,6 +497,24 @@ type AccountFeatures struct {
 	IscGithubRepo *bool `json:"iscGithubRepo,omitempty"`
 	// Enables new products list view
 	NewProductsList *bool `json:"newProductsList,omitempty"`
+	// Moves the helpHub to the sidebar
+	HelpHubInSidebar *bool `json:"helpHubInSidebar,omitempty"`
+	// Enable enforcement according to GitOps Plan. Includes locking user on billing page when not paying.
+	GitopsFreePlanEnforcement *bool `json:"gitopsFreePlanEnforcement,omitempty"`
+	// Enables grouped mode for environments view
+	GitopsEnvironmentsGroupedMode *bool `json:"gitopsEnvironmentsGroupedMode,omitempty"`
+	// Adds ability to promote files from relative path
+	RelativeFilesPromotions *bool `json:"relativeFilesPromotions,omitempty"`
+}
+
+// Account Gitops Usage
+type AccountGitopsUsage struct {
+	// UpdatedAt
+	UpdatedAt *string `json:"updatedAt,omitempty"`
+	// Applications
+	Applications *UsageState `json:"applications,omitempty"`
+	// Clusters
+	Clusters *UsageState `json:"clusters,omitempty"`
 }
 
 // Account Settings will hold a generic object with settings used by the UI
@@ -1003,6 +1023,16 @@ type AppResourceDifferenceRecord struct {
 	Metadata *ObjectMeta `json:"metadata"`
 	// Desired manifest
 	DesiredManifest *string `json:"desiredManifest,omitempty"`
+}
+
+// Repo Resource Manifest response input
+type AppResourceGitManifestInput struct {
+	// Resource git manifest
+	Content string `json:"content"`
+	// Resource source
+	Source *RepoResourceSourceInput `json:"source"`
+	// Synced revision metadata
+	SyncedRevisionMetadata *SyncedRevisionMetadataInput `json:"syncedRevisionMetadata,omitempty"`
 }
 
 // App Resource metadata
@@ -4480,7 +4510,7 @@ type GitopsAccount struct {
 	// AccountId
 	ID string `json:"id"`
 	// GitopsUsage
-	GitopsUsage *GitopsUsage `json:"gitopsUsage,omitempty"`
+	GitopsUsage *AccountGitopsUsage `json:"gitopsUsage,omitempty"`
 }
 
 // Gitops entity source
@@ -4645,18 +4675,6 @@ type GitopsReleaseSortArg struct {
 	Field GitopsReleasesSortingField `json:"field"`
 	// Order
 	Order SortingOrder `json:"order"`
-}
-
-// GitopsUsage
-type GitopsUsage struct {
-	// Cron Trace Id
-	CronTraceID *string `json:"cronTraceId,omitempty"`
-	// UpdatedAt
-	UpdatedAt *string `json:"updatedAt,omitempty"`
-	// Applications
-	Applications *UsageState `json:"applications,omitempty"`
-	// Clusters
-	Clusters *UsageState `json:"clusters,omitempty"`
 }
 
 // GoogleSSO
@@ -5556,6 +5574,10 @@ type IntegrationGenerationInput struct {
 	Operation ResourceOperation `json:"operation"`
 	// Yaml containing encrypted sealed secret
 	SealedSecretYaml *string `json:"sealedSecretYaml,omitempty"`
+	// Sealet secret git details of currently existing integration
+	SealedSecretGitData *AppResourceGitManifestInput `json:"sealedSecretGitData,omitempty"`
+	// Config map git details of currently existing integration
+	ConfigMapGitData *AppResourceGitManifestInput `json:"configMapGitData,omitempty"`
 }
 
 // IntegrationGenerationInput
@@ -6628,6 +6650,32 @@ type PipelineRef struct {
 	ProjectID string `json:"projectId"`
 }
 
+// Pipeline reference metadata
+type PipelineReferenceMetadata struct {
+	// Name of the entity
+	Name string `json:"name"`
+	// Namespace of the entity
+	Namespace *string `json:"namespace,omitempty"`
+	// Runtime of the entity
+	Runtime *string `json:"runtime,omitempty"`
+	// Group of the entity
+	Group *string `json:"group,omitempty"`
+	// Kind of the entity
+	Kind *string `json:"kind,omitempty"`
+	// Version of the entity
+	Version *string `json:"version,omitempty"`
+}
+
+// Pipeline reference with git manifest
+type PipelineReferenceWithGitManifest struct {
+	// Pipeline reference metadata
+	Metadata *PipelineReferenceMetadata `json:"metadata"`
+	// Pipeline reference git manifest file path
+	Path string `json:"path"`
+	// Pipeline reference git manifest
+	GitManifest string `json:"gitManifest"`
+}
+
 // Pipeline Slice
 type PipelineSlice struct {
 	// Pipeline edges
@@ -7014,6 +7062,8 @@ type ProductComponentFilterArgs struct {
 	PartialName *string `json:"partialName,omitempty"`
 	// Application names
 	AppNames []*string `json:"appNames,omitempty"`
+	// Application version
+	AppVersion *string `json:"appVersion,omitempty"`
 	// Filter by user favorite
 	Favorite *bool `json:"favorite,omitempty"`
 	// Issue key array
@@ -7142,6 +7192,22 @@ type ProductGitTriggerSelector struct {
 	Values []string `json:"values"`
 }
 
+// Products group for environments page in grouped mode
+type ProductGroupForEnvs struct {
+	// Product id
+	ID string `json:"id"`
+	// Product name
+	Name string `json:"name"`
+	// Application Version
+	AppVersion string `json:"appVersion"`
+	// Applications in Group
+	AppsCounter int `json:"appsCounter"`
+	// Has Errors
+	HasErrors bool `json:"hasErrors"`
+	// Product Components
+	ProductComponents []*ProductComponent `json:"productComponents"`
+}
+
 // Product Promotion Flow Selectors
 type ProductPromotionFlowSelectors struct {
 	// Entity db id
@@ -7149,6 +7215,18 @@ type ProductPromotionFlowSelectors struct {
 	// Group name
 	GitTriggerSelectors []*ProductGitTriggerSelector `json:"gitTriggerSelectors"`
 }
+
+// ProductReadModelEventPayload
+type ProductReadModelEventPayload struct {
+	// Type of DB entity
+	EntityType string `json:"entityType"`
+	// Type of DB event upsert/delete
+	EventType string `json:"eventType"`
+	// Reference to entity
+	Item *EntityReference `json:"item,omitempty"`
+}
+
+func (ProductReadModelEventPayload) IsReadModelEventPayload() {}
 
 // Product Release Entity
 type ProductReleaseEntity struct {
@@ -7610,6 +7688,8 @@ type PullRequest struct {
 	State PullRequestState `json:"state"`
 	// Pull request is merged
 	IsMerged bool `json:"isMerged"`
+	// Commit sha from the pull request merge
+	MergeCommitSha *string `json:"mergeCommitSHA,omitempty"`
 }
 
 // Pull request args
@@ -7846,6 +7926,16 @@ type RepoBitbucketCloudFilterArgsInput struct {
 	ProjectKey string `json:"projectKey"`
 	// Repo name
 	RepositorySlug string `json:"repositorySlug"`
+}
+
+// Repo Resource Source data input
+type RepoResourceSourceInput struct {
+	// Repository URL
+	RepoURL string `json:"repoURL"`
+	// Repository revision
+	Revision string `json:"revision"`
+	// Repository path
+	Path string `json:"path"`
 }
 
 // Runtime Errors Report Arguments
@@ -8482,6 +8572,8 @@ type Runtime struct {
 	Status *RuntimeStatus `json:"status"`
 	// True if the runtime is a configuration runtime
 	IsConfigurationRuntime bool `json:"isConfigurationRuntime"`
+	// True if the runtime is marked as skipped configuring as Argo App
+	IsSkippedConfiguringAsArgoApp bool `json:"isSkippedConfiguringAsArgoApp"`
 	// The internal shared configuration application name for this runtime
 	InternalSharedConfigAppName *string `json:"internalSharedConfigAppName,omitempty"`
 	// The in-cluster application name for this runtime
@@ -9452,6 +9544,26 @@ type SyncResultResource struct {
 	HookType *SyncHookType `json:"hookType,omitempty"`
 }
 
+// Synced revision metadata input
+type SyncedRevisionMetadataInput struct {
+	// Resource git manifest
+	Revision string `json:"revision"`
+	// Commit author
+	CommitAuthor *string `json:"commitAuthor,omitempty"`
+	// Commit date
+	CommitDate *string `json:"commitDate,omitempty"`
+	// Commit message
+	CommitMessage *string `json:"commitMessage,omitempty"`
+	// Git commit web url
+	CommitURL *string `json:"commitURL,omitempty"`
+	// Full web url to file in commit
+	FileURL *string `json:"fileURL,omitempty"`
+	// Author web profile url
+	ProfileURL *string `json:"profileURL,omitempty"`
+	// Author avatar url
+	AvatarURL *string `json:"avatarURL,omitempty"`
+}
+
 // SystemTypeOutput
 type SystemTypeOutput struct {
 	// SystemType
@@ -9712,10 +9824,12 @@ type UsageState struct {
 	Used *int `json:"used,omitempty"`
 	// Limit
 	Limit *int `json:"limit,omitempty"`
-	// IsReached
+	// Whether the usage has reached the limit
 	IsReached bool `json:"isReached"`
-	// IsExceeded
+	// Whether the usage has exceeded the limit
 	IsExceeded bool `json:"isExceeded"`
+	// Whether the usage has exceeded the limit to the point where we enforce harder
+	IsHardExceeded bool `json:"isHardExceeded"`
 }
 
 // User

--- a/pkg/model/platform/models_gen.go
+++ b/pkg/model/platform/models_gen.go
@@ -505,6 +505,10 @@ type AccountFeatures struct {
 	GitopsEnvironmentsGroupedMode *bool `json:"gitopsEnvironmentsGroupedMode,omitempty"`
 	// Adds ability to promote files from relative path
 	RelativeFilesPromotions *bool `json:"relativeFilesPromotions,omitempty"`
+	// Adds ability to connect Gitlab as git provider in runtime installation wizard
+	GitlabSupportInRuntimeWizard *bool `json:"gitlabSupportInRuntimeWizard,omitempty"`
+	// Adds ability to connect Bitbucket as git provider in runtime installation wizard
+	BitbucketSupportInRuntimeWizard *bool `json:"bitbucketSupportInRuntimeWizard,omitempty"`
 }
 
 // Account Gitops Usage
@@ -10418,6 +10422,7 @@ const (
 	AbacActionNamesRolloutAbort           AbacActionNames = "ROLLOUT_ABORT"
 	AbacActionNamesRolloutPause           AbacActionNames = "ROLLOUT_PAUSE"
 	AbacActionNamesRolloutPromoteFull     AbacActionNames = "ROLLOUT_PROMOTE_FULL"
+	AbacActionNamesRolloutRestart         AbacActionNames = "ROLLOUT_RESTART"
 	AbacActionNamesRolloutResume          AbacActionNames = "ROLLOUT_RESUME"
 	AbacActionNamesRolloutRetry           AbacActionNames = "ROLLOUT_RETRY"
 	AbacActionNamesRolloutSkipCurrentStep AbacActionNames = "ROLLOUT_SKIP_CURRENT_STEP"
@@ -10445,6 +10450,7 @@ var AllAbacActionNames = []AbacActionNames{
 	AbacActionNamesRolloutAbort,
 	AbacActionNamesRolloutPause,
 	AbacActionNamesRolloutPromoteFull,
+	AbacActionNamesRolloutRestart,
 	AbacActionNamesRolloutResume,
 	AbacActionNamesRolloutRetry,
 	AbacActionNamesRolloutSkipCurrentStep,
@@ -10459,7 +10465,7 @@ var AllAbacActionNames = []AbacActionNames{
 
 func (e AbacActionNames) IsValid() bool {
 	switch e {
-	case AbacActionNamesAccessArtifacts, AbacActionNamesAccessLogs, AbacActionNamesAppRollback, AbacActionNamesCreate, AbacActionNamesDeleteResource, AbacActionNamesExecToPod, AbacActionNamesPromoteTo, AbacActionNamesRefresh, AbacActionNamesRestart, AbacActionNamesResubmit, AbacActionNamesRetryRelease, AbacActionNamesRolloutAbort, AbacActionNamesRolloutPause, AbacActionNamesRolloutPromoteFull, AbacActionNamesRolloutResume, AbacActionNamesRolloutRetry, AbacActionNamesRolloutSkipCurrentStep, AbacActionNamesStop, AbacActionNamesSync, AbacActionNamesTerminate, AbacActionNamesTerminateSync, AbacActionNamesTriggerPromotion, AbacActionNamesView, AbacActionNamesViewPodLogs:
+	case AbacActionNamesAccessArtifacts, AbacActionNamesAccessLogs, AbacActionNamesAppRollback, AbacActionNamesCreate, AbacActionNamesDeleteResource, AbacActionNamesExecToPod, AbacActionNamesPromoteTo, AbacActionNamesRefresh, AbacActionNamesRestart, AbacActionNamesResubmit, AbacActionNamesRetryRelease, AbacActionNamesRolloutAbort, AbacActionNamesRolloutPause, AbacActionNamesRolloutPromoteFull, AbacActionNamesRolloutRestart, AbacActionNamesRolloutResume, AbacActionNamesRolloutRetry, AbacActionNamesRolloutSkipCurrentStep, AbacActionNamesStop, AbacActionNamesSync, AbacActionNamesTerminate, AbacActionNamesTerminateSync, AbacActionNamesTriggerPromotion, AbacActionNamesView, AbacActionNamesViewPodLogs:
 		return true
 	}
 	return false

--- a/pkg/model/promotion-orchestrator/models_gen.go
+++ b/pkg/model/promotion-orchestrator/models_gen.go
@@ -497,6 +497,10 @@ type AccountFeatures struct {
 	GitopsEnvironmentsGroupedMode *bool `json:"gitopsEnvironmentsGroupedMode,omitempty"`
 	// Adds ability to promote files from relative path
 	RelativeFilesPromotions *bool `json:"relativeFilesPromotions,omitempty"`
+	// Adds ability to connect Gitlab as git provider in runtime installation wizard
+	GitlabSupportInRuntimeWizard *bool `json:"gitlabSupportInRuntimeWizard,omitempty"`
+	// Adds ability to connect Bitbucket as git provider in runtime installation wizard
+	BitbucketSupportInRuntimeWizard *bool `json:"bitbucketSupportInRuntimeWizard,omitempty"`
 }
 
 // Account Gitops Usage
@@ -9654,6 +9658,7 @@ const (
 	AbacActionNamesRolloutAbort           AbacActionNames = "ROLLOUT_ABORT"
 	AbacActionNamesRolloutPause           AbacActionNames = "ROLLOUT_PAUSE"
 	AbacActionNamesRolloutPromoteFull     AbacActionNames = "ROLLOUT_PROMOTE_FULL"
+	AbacActionNamesRolloutRestart         AbacActionNames = "ROLLOUT_RESTART"
 	AbacActionNamesRolloutResume          AbacActionNames = "ROLLOUT_RESUME"
 	AbacActionNamesRolloutRetry           AbacActionNames = "ROLLOUT_RETRY"
 	AbacActionNamesRolloutSkipCurrentStep AbacActionNames = "ROLLOUT_SKIP_CURRENT_STEP"
@@ -9681,6 +9686,7 @@ var AllAbacActionNames = []AbacActionNames{
 	AbacActionNamesRolloutAbort,
 	AbacActionNamesRolloutPause,
 	AbacActionNamesRolloutPromoteFull,
+	AbacActionNamesRolloutRestart,
 	AbacActionNamesRolloutResume,
 	AbacActionNamesRolloutRetry,
 	AbacActionNamesRolloutSkipCurrentStep,
@@ -9695,7 +9701,7 @@ var AllAbacActionNames = []AbacActionNames{
 
 func (e AbacActionNames) IsValid() bool {
 	switch e {
-	case AbacActionNamesAccessArtifacts, AbacActionNamesAccessLogs, AbacActionNamesAppRollback, AbacActionNamesCreate, AbacActionNamesDeleteResource, AbacActionNamesExecToPod, AbacActionNamesPromoteTo, AbacActionNamesRefresh, AbacActionNamesRestart, AbacActionNamesResubmit, AbacActionNamesRetryRelease, AbacActionNamesRolloutAbort, AbacActionNamesRolloutPause, AbacActionNamesRolloutPromoteFull, AbacActionNamesRolloutResume, AbacActionNamesRolloutRetry, AbacActionNamesRolloutSkipCurrentStep, AbacActionNamesStop, AbacActionNamesSync, AbacActionNamesTerminate, AbacActionNamesTerminateSync, AbacActionNamesTriggerPromotion, AbacActionNamesView, AbacActionNamesViewPodLogs:
+	case AbacActionNamesAccessArtifacts, AbacActionNamesAccessLogs, AbacActionNamesAppRollback, AbacActionNamesCreate, AbacActionNamesDeleteResource, AbacActionNamesExecToPod, AbacActionNamesPromoteTo, AbacActionNamesRefresh, AbacActionNamesRestart, AbacActionNamesResubmit, AbacActionNamesRetryRelease, AbacActionNamesRolloutAbort, AbacActionNamesRolloutPause, AbacActionNamesRolloutPromoteFull, AbacActionNamesRolloutRestart, AbacActionNamesRolloutResume, AbacActionNamesRolloutRetry, AbacActionNamesRolloutSkipCurrentStep, AbacActionNamesStop, AbacActionNamesSync, AbacActionNamesTerminate, AbacActionNamesTerminateSync, AbacActionNamesTriggerPromotion, AbacActionNamesView, AbacActionNamesViewPodLogs:
 		return true
 	}
 	return false

--- a/pkg/model/promotion-orchestrator/models_gen.go
+++ b/pkg/model/promotion-orchestrator/models_gen.go
@@ -385,6 +385,8 @@ type AccountFeatures struct {
 	ClassicEnvironments *bool `json:"classicEnvironments,omitempty"`
 	// Hide git-sources and related applications without git permissions and when permissions are not provided
 	CsdpFilterAppsByGitPermissions *bool `json:"csdpFilterAppsByGitPermissions,omitempty"`
+	// Gitops Application Tree optimization. It will use improved MongoDB agregation pipeline when enabled. Gitops apps and app sets will be extracted from DB without heavy manifest fields (when need to read >2k items)
+	CsdpAppAndAppSetWithoutManifestFields *bool `json:"csdpAppAndAppSetWithoutManifestFields,omitempty"`
 	// Hide Compositions item in navigation menu
 	HideCompositionsMenuItem *bool `json:"hideCompositionsMenuItem,omitempty"`
 	// Hide Helm Boards item in navigation menu
@@ -479,7 +481,7 @@ type AccountFeatures struct {
 	UnmappedAppsProductView *bool `json:"unmappedAppsProductView,omitempty"`
 	// Hide native workflow link
 	HideNativeWorkflowLink *bool `json:"hideNativeWorkflowLink,omitempty"`
-	// Locking user on billing page when not paying
+	// Enable enforcement according to GitOps Plan. Includes monitoring resource limits and disabling actions, showing banners when plan limits reached.
 	GitopsPlanEnforcement *bool `json:"gitopsPlanEnforcement,omitempty"`
 	// Hides delete, resubmit, terminate and suspend workflow actions
 	HideWorkflowActions *bool `json:"hideWorkflowActions,omitempty"`
@@ -487,6 +489,24 @@ type AccountFeatures struct {
 	IscGithubRepo *bool `json:"iscGithubRepo,omitempty"`
 	// Enables new products list view
 	NewProductsList *bool `json:"newProductsList,omitempty"`
+	// Moves the helpHub to the sidebar
+	HelpHubInSidebar *bool `json:"helpHubInSidebar,omitempty"`
+	// Enable enforcement according to GitOps Plan. Includes locking user on billing page when not paying.
+	GitopsFreePlanEnforcement *bool `json:"gitopsFreePlanEnforcement,omitempty"`
+	// Enables grouped mode for environments view
+	GitopsEnvironmentsGroupedMode *bool `json:"gitopsEnvironmentsGroupedMode,omitempty"`
+	// Adds ability to promote files from relative path
+	RelativeFilesPromotions *bool `json:"relativeFilesPromotions,omitempty"`
+}
+
+// Account Gitops Usage
+type AccountGitopsUsage struct {
+	// UpdatedAt
+	UpdatedAt *string `json:"updatedAt,omitempty"`
+	// Applications
+	Applications *UsageState `json:"applications,omitempty"`
+	// Clusters
+	Clusters *UsageState `json:"clusters,omitempty"`
 }
 
 // Account Settings will hold a generic object with settings used by the UI
@@ -1025,6 +1045,16 @@ type AppResourceDifferenceRecord struct {
 	Metadata *ObjectMeta `json:"metadata"`
 	// Desired manifest
 	DesiredManifest *string `json:"desiredManifest,omitempty"`
+}
+
+// Repo Resource Manifest response input
+type AppResourceGitManifestInput struct {
+	// Resource git manifest
+	Content string `json:"content"`
+	// Resource source
+	Source *RepoResourceSourceInput `json:"source"`
+	// Synced revision metadata
+	SyncedRevisionMetadata *SyncedRevisionMetadataInput `json:"syncedRevisionMetadata,omitempty"`
 }
 
 // Application entity
@@ -4062,7 +4092,7 @@ type GitopsAccount struct {
 	// AccountId
 	ID string `json:"id"`
 	// GitopsUsage
-	GitopsUsage *GitopsUsage `json:"gitopsUsage,omitempty"`
+	GitopsUsage *AccountGitopsUsage `json:"gitopsUsage,omitempty"`
 }
 
 // Gitops entity source
@@ -4219,18 +4249,6 @@ type GitopsReleaseSlice struct {
 	Edges []*GitopsReleaseEdge `json:"edges"`
 	// Slice information
 	PageInfo *SliceInfo `json:"pageInfo"`
-}
-
-// GitopsUsage
-type GitopsUsage struct {
-	// Cron Trace Id
-	CronTraceID *string `json:"cronTraceId,omitempty"`
-	// UpdatedAt
-	UpdatedAt *string `json:"updatedAt,omitempty"`
-	// Applications
-	Applications *UsageState `json:"applications,omitempty"`
-	// Clusters
-	Clusters *UsageState `json:"clusters,omitempty"`
 }
 
 // GoogleSSO
@@ -4940,6 +4958,10 @@ type IntegrationGenerationInput struct {
 	Operation ResourceOperation `json:"operation"`
 	// Yaml containing encrypted sealed secret
 	SealedSecretYaml *string `json:"sealedSecretYaml,omitempty"`
+	// Sealet secret git details of currently existing integration
+	SealedSecretGitData *AppResourceGitManifestInput `json:"sealedSecretGitData,omitempty"`
+	// Config map git details of currently existing integration
+	ConfigMapGitData *AppResourceGitManifestInput `json:"configMapGitData,omitempty"`
 }
 
 // IntegrationGenerationInput
@@ -5912,6 +5934,32 @@ type PipelineRef struct {
 	ProjectID string `json:"projectId"`
 }
 
+// Pipeline reference metadata
+type PipelineReferenceMetadata struct {
+	// Name of the entity
+	Name string `json:"name"`
+	// Namespace of the entity
+	Namespace *string `json:"namespace,omitempty"`
+	// Runtime of the entity
+	Runtime *string `json:"runtime,omitempty"`
+	// Group of the entity
+	Group *string `json:"group,omitempty"`
+	// Kind of the entity
+	Kind *string `json:"kind,omitempty"`
+	// Version of the entity
+	Version *string `json:"version,omitempty"`
+}
+
+// Pipeline reference with git manifest
+type PipelineReferenceWithGitManifest struct {
+	// Pipeline reference metadata
+	Metadata *PipelineReferenceMetadata `json:"metadata"`
+	// Pipeline reference git manifest file path
+	Path string `json:"path"`
+	// Pipeline reference git manifest
+	GitManifest string `json:"gitManifest"`
+}
+
 // Pipeline Slice
 type PipelineSlice struct {
 	// Pipeline edges
@@ -6298,6 +6346,8 @@ type ProductComponentFilterArgs struct {
 	PartialName *string `json:"partialName,omitempty"`
 	// Application names
 	AppNames []*string `json:"appNames,omitempty"`
+	// Application version
+	AppVersion *string `json:"appVersion,omitempty"`
 	// Filter by user favorite
 	Favorite *bool `json:"favorite,omitempty"`
 	// Issue key array
@@ -6424,6 +6474,22 @@ type ProductGitTriggerSelector struct {
 	Operator MatchExpressionOperator `json:"operator"`
 	// Values
 	Values []string `json:"values"`
+}
+
+// Products group for environments page in grouped mode
+type ProductGroupForEnvs struct {
+	// Product id
+	ID string `json:"id"`
+	// Product name
+	Name string `json:"name"`
+	// Application Version
+	AppVersion string `json:"appVersion"`
+	// Applications in Group
+	AppsCounter int `json:"appsCounter"`
+	// Has Errors
+	HasErrors bool `json:"hasErrors"`
+	// Product Components
+	ProductComponents []*ProductComponent `json:"productComponents"`
 }
 
 // Product Promotion Flow Selectors
@@ -7078,6 +7144,8 @@ type PullRequest struct {
 	State PullRequestState `json:"state"`
 	// Pull request is merged
 	IsMerged bool `json:"isMerged"`
+	// Commit sha from the pull request merge
+	MergeCommitSha *string `json:"mergeCommitSHA,omitempty"`
 }
 
 // Pull request args
@@ -7326,6 +7394,16 @@ type RepoBitbucketCloudFilterArgsInput struct {
 	ProjectKey string `json:"projectKey"`
 	// Repo name
 	RepositorySlug string `json:"repositorySlug"`
+}
+
+// Repo Resource Source data input
+type RepoResourceSourceInput struct {
+	// Repository URL
+	RepoURL string `json:"repoURL"`
+	// Repository revision
+	Revision string `json:"revision"`
+	// Repository path
+	Path string `json:"path"`
 }
 
 // Runtime Errors Report Arguments
@@ -7948,6 +8026,8 @@ type Runtime struct {
 	Status *RuntimeStatus `json:"status"`
 	// True if the runtime is a configuration runtime
 	IsConfigurationRuntime bool `json:"isConfigurationRuntime"`
+	// True if the runtime is marked as skipped configuring as Argo App
+	IsSkippedConfiguringAsArgoApp bool `json:"isSkippedConfiguringAsArgoApp"`
 	// The internal shared configuration application name for this runtime
 	InternalSharedConfigAppName *string `json:"internalSharedConfigAppName,omitempty"`
 	// The in-cluster application name for this runtime
@@ -8800,6 +8880,26 @@ type SyncResultResource struct {
 	HookType *SyncHookType `json:"hookType,omitempty"`
 }
 
+// Synced revision metadata input
+type SyncedRevisionMetadataInput struct {
+	// Resource git manifest
+	Revision string `json:"revision"`
+	// Commit author
+	CommitAuthor *string `json:"commitAuthor,omitempty"`
+	// Commit date
+	CommitDate *string `json:"commitDate,omitempty"`
+	// Commit message
+	CommitMessage *string `json:"commitMessage,omitempty"`
+	// Git commit web url
+	CommitURL *string `json:"commitURL,omitempty"`
+	// Full web url to file in commit
+	FileURL *string `json:"fileURL,omitempty"`
+	// Author web profile url
+	ProfileURL *string `json:"profileURL,omitempty"`
+	// Author avatar url
+	AvatarURL *string `json:"avatarURL,omitempty"`
+}
+
 // SystemTypeOutput
 type SystemTypeOutput struct {
 	// SystemType
@@ -9030,10 +9130,12 @@ type UsageState struct {
 	Used *int `json:"used,omitempty"`
 	// Limit
 	Limit *int `json:"limit,omitempty"`
-	// IsReached
+	// Whether the usage has reached the limit
 	IsReached bool `json:"isReached"`
-	// IsExceeded
+	// Whether the usage has exceeded the limit
 	IsExceeded bool `json:"isExceeded"`
+	// Whether the usage has exceeded the limit to the point where we enforce harder
+	IsHardExceeded bool `json:"isHardExceeded"`
 }
 
 // User


### PR DESCRIPTION
The main change is "MergedCommitSha" on the PR struct which is now used by the gitops operator to know if it can resume a workflow.

Relevant PRs:
https://github.com/codefresh-io/argo-platform/pull/6572
https://github.com/codefresh-io/codefresh-gitops-operator/pull/239